### PR TITLE
fix(ansibleWarning): Use ip filters from ansible.utils second part

### DIFF
--- a/templates/dhcpd.conf.j2
+++ b/templates/dhcpd.conf.j2
@@ -5,7 +5,7 @@
 {% endfor %}
 
 {% for subnet, options in isc_dhcp_server_subnets.items() %}
-{% if subnet | ansible.netcommon.ipv4 %}
+{% if subnet | ansible.utils.ipv4 %}
 subnet {{ subnet | ansible.utils.ipaddr('network') }} netmask {{ subnet | ansible.utils.ipaddr('netmask') }} {
 {% if options | map('regex_search', '^range ') | select('string') == [] and subnet | ansible.utils.ipaddr('prefix') <= 25 %}
   range {{ subnet | ansible.utils.nthhost(100) }} {{ subnet | ansible.utils.nthhost(-2) }};


### PR DESCRIPTION
They are deprecated in ansible.netcommon

Follow up to #4